### PR TITLE
Add support for </>

### DIFF
--- a/sequila/sequila-cli/src/main.rs
+++ b/sequila/sequila-cli/src/main.rs
@@ -41,7 +41,7 @@ async fn main() -> Result<()> {
         .with_repartition_joins(false);
     let rocket = emojis::get_by_shortcode("rocket").unwrap();
     info!("Starting SeQuiLa-native CLI {rocket}...");
-    let mut ctx = SessionContext::new_with_sequila(config);
+    let ctx = SessionContext::new_with_sequila(config);
     let mut print_options = PrintOptions {
         format: datafusion_cli::print_format::PrintFormat::Table,
         quiet: false,
@@ -50,9 +50,9 @@ async fn main() -> Result<()> {
     };
 
     if !args.file.is_empty() {
-        exec::exec_from_files(&mut ctx, args.file, &print_options).await?;
+        exec::exec_from_files(&ctx, args.file, &print_options).await?;
     } else {
-        exec::exec_from_repl(&mut ctx, &mut print_options)
+        exec::exec_from_repl(&ctx, &mut print_options)
             .await
             .map_err(|e| DataFusionError::External(Box::new(e)))
             .expect("Error");

--- a/sequila/sequila-cli/src/main.rs
+++ b/sequila/sequila-cli/src/main.rs
@@ -103,7 +103,7 @@ async fn test_interval_rule_eq() -> datafusion::error::Result<()> {
 
     let plan = df.explain(false, false)?.collect().await?;
     let formatted = datafusion::arrow::util::pretty::pretty_format_batches(&plan)?.to_string();
-    assert!(!formatted.contains("IntervalJoinExec: "));
+    assert!(formatted.contains("IntervalJoinExec: "));
 
     Ok(())
 }

--- a/sequila/sequila-core/src/physical_planner/intervals.rs
+++ b/sequila/sequila-core/src/physical_planner/intervals.rs
@@ -1,0 +1,538 @@
+use datafusion::common::tree_node::{Transformed, TransformedResult, TreeNode};
+use datafusion::common::JoinSide;
+use datafusion::logical_expr::Operator;
+use datafusion::physical_expr::expressions::{lit, BinaryExpr, Column};
+use datafusion::physical_expr::PhysicalExpr;
+use datafusion::physical_plan::joins::utils::{ColumnIndex, JoinFilter};
+use std::sync::Arc;
+
+#[derive(Debug, Clone)]
+pub struct ColInterval {
+    pub start: Arc<dyn PhysicalExpr>,
+    pub end: Arc<dyn PhysicalExpr>,
+}
+
+impl ColInterval {
+    fn start(&self) -> Arc<dyn PhysicalExpr> {
+        self.start.clone()
+    }
+    fn end(&self) -> Arc<dyn PhysicalExpr> {
+        self.end.clone()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ColIntervals {
+    pub left_interval: ColInterval,
+    pub right_interval: ColInterval,
+}
+
+pub fn parse(filter: Option<&JoinFilter>) -> Option<ColIntervals> {
+    if let Some(filter) = filter {
+        try_parse(filter).inspect_err(|e| log::debug!("{}", e)).ok()
+    } else {
+        log::debug!("filter is not provided");
+        None
+    }
+}
+
+fn map_column_to_source_schema(
+    expr: Arc<dyn PhysicalExpr>,
+    indices: &[ColumnIndex],
+) -> (Arc<dyn PhysicalExpr>, JoinSide) {
+    // we need to rewrite a provided PhysicalExpr to map the columns to the source index.
+    // When join filter is constructed, the column index points to the position in the resulting batch.
+    // Currently, we expect the sub expression to contain exactly 1 column.
+
+    let mut side: Option<JoinSide> = None;
+    let message = format!("complex sub queries are not supported {:?}", expr);
+
+    expr.transform_up(|node| {
+        if let Some(column) = node.as_any().downcast_ref::<Column>() {
+            let new_column = Column::new(column.name(), indices[column.index()].index);
+            if side.is_some() {
+                panic!("{}", message);
+            }
+            side = Some(indices[column.index()].side);
+            Ok(Transformed::yes(Arc::new(new_column)))
+        } else {
+            Ok(Transformed::no(node))
+        }
+    })
+    .data()
+    .map(|expr| (expr, side.expect("side not found")))
+    .unwrap()
+}
+
+fn minus_one(expr: Arc<dyn PhysicalExpr>) -> Arc<dyn PhysicalExpr> {
+    Arc::new(BinaryExpr::new(expr, Operator::Minus, lit(1)))
+}
+
+fn parse_condition(
+    expr: &BinaryExpr,
+    indices: &[ColumnIndex],
+    inner: &mut IntervalBuilder,
+) -> Result<(), String> {
+    // There are 8 possibilities that we need to consider when parsing a filter expression:
+    // re >= ls AND le >= rs
+    // re >= ls AND rs <= le
+    // ls <= re AND le >= rs
+    // ls <= re AND rs <= le
+    // le >= rs AND re >= ls
+    // le >= rs AND ls <= re
+    // rs <= le AND re >= ls
+    // rs <= le AND ls <= re
+
+    let is_lt = matches!(expr.op(), Operator::Lt);
+    let is_lteq = matches!(expr.op(), Operator::LtEq);
+    let is_gteq = matches!(expr.op(), Operator::GtEq);
+    let is_gt = matches!(expr.op(), Operator::Gt);
+
+    if !(is_lteq || is_gteq || is_lt || is_gt) {
+        return Err(format!("Unsupported operator: {}", expr.op()));
+    }
+
+    match map_column_to_source_schema(expr.left().clone(), indices) {
+        (rs, JoinSide::Right) if is_lteq || is_lt => {
+            match map_column_to_source_schema(expr.right().clone(), indices) {
+                (le, JoinSide::Left) => {
+                    let le = if is_lt { minus_one(le) } else { le };
+                    inner.with_rs(rs).with_le(le);
+                    Ok(())
+                }
+                _ => Err("couldn't parse as rs </<= le".to_string()),
+            }
+        }
+        (ls, JoinSide::Left) if is_lteq || is_lt => {
+            match map_column_to_source_schema(expr.right().clone(), indices) {
+                (re, JoinSide::Right) => {
+                    let re = if is_lt { minus_one(re) } else { re };
+                    inner.with_re(re).with_ls(ls);
+                    Ok(())
+                }
+                _ => Err("couldn't parse as ls </<= re".to_string()),
+            }
+        }
+        (re, JoinSide::Right) if is_gteq || is_gt => {
+            match map_column_to_source_schema(expr.right().clone(), indices) {
+                (ls, JoinSide::Left) => {
+                    let re = if is_gt { minus_one(re) } else { re };
+                    inner.with_re(re).with_ls(ls);
+                    Ok(())
+                }
+                _ => Err("couldn't parse as re >/>= ls".to_string()),
+            }
+        }
+        (le, JoinSide::Left) if is_gteq || is_gt => {
+            match map_column_to_source_schema(expr.right().clone(), indices) {
+                (rs, JoinSide::Right) => {
+                    let le = if is_gt { minus_one(le) } else { le };
+                    inner.with_rs(rs).with_le(le);
+                    Ok(())
+                }
+                _ => Err("couldn't parse as le >/>= rs".to_string()),
+            }
+        }
+        _ => Err("couldn't parse left side as neither 'rs </<=' nor 'ls </<=' nor 're >/>=' nor 'le >/>='".to_string()),
+    }
+}
+
+struct IntervalBuilder {
+    ls: Option<Arc<dyn PhysicalExpr>>,
+    le: Option<Arc<dyn PhysicalExpr>>,
+    rs: Option<Arc<dyn PhysicalExpr>>,
+    re: Option<Arc<dyn PhysicalExpr>>,
+}
+
+impl IntervalBuilder {
+    fn empty() -> IntervalBuilder {
+        IntervalBuilder {
+            ls: None,
+            le: None,
+            rs: None,
+            re: None,
+        }
+    }
+
+    fn with_ls(&mut self, ls: Arc<dyn PhysicalExpr>) -> &mut Self {
+        if self.ls.is_some() {
+            panic!("ls must not be called twice")
+        }
+        self.ls = Some(ls);
+        self
+    }
+    fn with_le(&mut self, le: Arc<dyn PhysicalExpr>) -> &mut Self {
+        if self.le.is_some() {
+            panic!("le must not be called twice")
+        }
+        self.le = Some(le);
+        self
+    }
+    fn with_rs(&mut self, rs: Arc<dyn PhysicalExpr>) -> &mut Self {
+        if self.rs.is_some() {
+            panic!("rs must not be called twice")
+        }
+        self.rs = Some(rs);
+        self
+    }
+    fn with_re(&mut self, re: Arc<dyn PhysicalExpr>) -> &mut Self {
+        if self.re.is_some() {
+            panic!("re must not be called twice")
+        }
+        self.re = Some(re);
+        self
+    }
+
+    fn finish(self) -> ColIntervals {
+        let l_interval = ColInterval {
+            start: self.ls.expect("ls must be set"),
+            end: self.le.expect("le must be set"),
+        };
+        let r_interval = ColInterval {
+            start: self.rs.expect("rs must be set"),
+            end: self.re.expect("re must be set"),
+        };
+
+        ColIntervals {
+            left_interval: l_interval,
+            right_interval: r_interval,
+        }
+    }
+}
+
+fn try_parse(filter: &JoinFilter) -> Result<ColIntervals, String> {
+    let mut inner = IntervalBuilder::empty();
+
+    let expr = filter
+        .expression()
+        .as_any()
+        .downcast_ref::<BinaryExpr>()
+        .ok_or("couldn't cast filter to BinaryExpr")?;
+
+    if !matches!(expr.op(), Operator::And) {
+        return Err("expr.op() is not AND".to_string());
+    }
+
+    let left = expr
+        .left()
+        .as_any()
+        .downcast_ref::<BinaryExpr>()
+        .ok_or("couldn't cast left side to BinaryExpr")?;
+    let right = expr
+        .right()
+        .as_any()
+        .downcast_ref::<BinaryExpr>()
+        .ok_or("couldn't cast right side to BinaryExpr")?;
+    let indices = filter.column_indices();
+
+    parse_condition(left, indices, &mut inner)?;
+    parse_condition(right, indices, &mut inner)?;
+
+    Ok(inner.finish())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::common::tree_node::TreeNodeRecursion;
+    use datafusion::error::{DataFusionError, Result};
+    use datafusion::physical_plan::joins::{HashJoinExec, NestedLoopJoinExec};
+    use datafusion::physical_plan::ExecutionPlan;
+    use datafusion::prelude::SessionContext;
+
+    async fn extract_filter(condition: &str) -> Result<ColIntervals> {
+        let ctx = SessionContext::new();
+        ctx.sql("CREATE TABLE IF NOT EXISTS a (contig TEXT, l_start INT, l_end INT) AS VALUES ('a', 1, 2), ('b', 3, 4)").await?;
+        ctx.sql("CREATE TABLE IF NOT EXISTS b (contig TEXT, name TEXT, r_end INT, r_start INT) AS VALUES ('a','x', 1, 2), ('b','x', 3, 4)").await?;
+
+        let query = format!("SELECT * FROM a JOIN b ON a.contig = b.contig AND {condition}");
+
+        let ds = ctx.sql(query.as_str()).await?;
+        let plan = ds.create_physical_plan().await?;
+
+        let filter: &JoinFilter = find_join_filter(&plan)?;
+
+        try_parse(filter).map_err(|e| DataFusionError::Internal(e))
+    }
+
+    #[tokio::test]
+    async fn test_all_comp_combinations_for_gteq_lteq() -> Result<()> {
+        let l_start = Column::new("l_start", 1);
+        let l_end = Column::new("l_end", 2);
+        let r_start = Column::new("r_start", 3);
+        let r_end = Column::new("r_end", 2);
+
+        let condition = "b.r_end >= a.l_start AND a.l_end >= b.r_start";
+        let ColIntervals {
+            left_interval: left,
+            right_interval: right,
+        } = extract_filter(condition).await?;
+
+        assert_eq!(to_column(left.start), l_start);
+        assert_eq!(to_column(left.end), l_end);
+        assert_eq!(to_column(right.start), r_start);
+        assert_eq!(to_column(right.end), r_end);
+
+        let condition = "b.r_end >= a.l_start AND b.r_start <= a.l_end";
+        let ColIntervals {
+            left_interval: left,
+            right_interval: right,
+        } = extract_filter(condition).await?;
+
+        assert_eq!(to_column(left.start), l_start);
+        assert_eq!(to_column(left.end), l_end);
+        assert_eq!(to_column(right.start), r_start);
+        assert_eq!(to_column(right.end), r_end);
+
+        let condition = "a.l_start <= b.r_end AND a.l_end >= b.r_start";
+        let ColIntervals {
+            left_interval: left,
+            right_interval: right,
+        } = extract_filter(condition).await?;
+
+        assert_eq!(to_column(left.start), l_start);
+        assert_eq!(to_column(left.end), l_end);
+        assert_eq!(to_column(right.start), r_start);
+        assert_eq!(to_column(right.end), r_end);
+
+        let condition = "a.l_start <= b.r_end AND b.r_start <= a.l_end";
+        let ColIntervals {
+            left_interval: left,
+            right_interval: right,
+        } = extract_filter(condition).await?;
+
+        assert_eq!(to_column(left.start), l_start);
+        assert_eq!(to_column(left.end), l_end);
+        assert_eq!(to_column(right.start), r_start);
+        assert_eq!(to_column(right.end), r_end);
+
+        let condition = "a.l_end >= b.r_start AND b.r_end >= a.l_start";
+        let ColIntervals {
+            left_interval: left,
+            right_interval: right,
+        } = extract_filter(condition).await?;
+
+        assert_eq!(to_column(left.start), l_start);
+        assert_eq!(to_column(left.end), l_end);
+        assert_eq!(to_column(right.start), r_start);
+        assert_eq!(to_column(right.end), r_end);
+
+        let condition = "a.l_end >= b.r_start AND a.l_start <= b.r_end";
+        let ColIntervals {
+            left_interval: left,
+            right_interval: right,
+        } = extract_filter(condition).await?;
+
+        assert_eq!(to_column(left.start), l_start);
+        assert_eq!(to_column(left.end), l_end);
+        assert_eq!(to_column(right.start), r_start);
+        assert_eq!(to_column(right.end), r_end);
+
+        let condition = "b.r_start <= a.l_end AND b.r_end >= a.l_start";
+        let ColIntervals {
+            left_interval: left,
+            right_interval: right,
+        } = extract_filter(condition).await?;
+
+        assert_eq!(to_column(left.start), l_start);
+        assert_eq!(to_column(left.end), l_end);
+        assert_eq!(to_column(right.start), r_start);
+        assert_eq!(to_column(right.end), r_end);
+
+        let condition = "b.r_start <= a.l_end AND a.l_start <= b.r_end";
+        let ColIntervals {
+            left_interval: left,
+            right_interval: right,
+        } = extract_filter(condition).await?;
+
+        assert_eq!(to_column(left.start), l_start);
+        assert_eq!(to_column(left.end), l_end);
+        assert_eq!(to_column(right.start), r_start);
+        assert_eq!(to_column(right.end), r_end);
+
+        let condition = "b.r_start <= a.l_end OR a.l_start <= b.r_end";
+        let error = extract_filter(condition).await;
+        assert!(error.is_err());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_all_comp_combinations_for_gt_lt() -> Result<()> {
+        let l_start = Column::new("l_start", 1);
+        let l_end = BinaryExpr::new(Arc::new(Column::new("l_end", 2)), Operator::Minus, lit(1));
+        let r_start = Column::new("r_start", 3);
+        let r_end = BinaryExpr::new(Arc::new(Column::new("r_end", 2)), Operator::Minus, lit(1));
+
+        let condition = "b.r_end > a.l_start AND a.l_end > b.r_start";
+        let ColIntervals {
+            left_interval: left,
+            right_interval: right,
+        } = extract_filter(condition).await?;
+
+        assert_eq!(to_column(left.start), l_start);
+        assert_eq!(format!("{:?}", to_binary(left.end)), format!("{:?}", l_end));
+        assert_eq!(to_column(right.start), r_start);
+        assert_eq!(
+            format!("{:?}", to_binary(right.end)),
+            format!("{:?}", r_end)
+        );
+
+        let condition = "b.r_end > a.l_start AND b.r_start < a.l_end";
+        let ColIntervals {
+            left_interval: left,
+            right_interval: right,
+        } = extract_filter(condition).await?;
+
+        assert_eq!(to_column(left.start), l_start);
+        assert_eq!(format!("{:?}", to_binary(left.end)), format!("{:?}", l_end));
+        assert_eq!(to_column(right.start), r_start);
+        assert_eq!(
+            format!("{:?}", to_binary(right.end)),
+            format!("{:?}", r_end)
+        );
+
+        let condition = "a.l_start < b.r_end AND a.l_end > b.r_start";
+        let ColIntervals {
+            left_interval: left,
+            right_interval: right,
+        } = extract_filter(condition).await?;
+
+        assert_eq!(to_column(left.start), l_start);
+        assert_eq!(format!("{:?}", to_binary(left.end)), format!("{:?}", l_end));
+        assert_eq!(to_column(right.start), r_start);
+        assert_eq!(
+            format!("{:?}", to_binary(right.end)),
+            format!("{:?}", r_end)
+        );
+
+        let condition = "a.l_start < b.r_end AND b.r_start < a.l_end";
+        let ColIntervals {
+            left_interval: left,
+            right_interval: right,
+        } = extract_filter(condition).await?;
+
+        assert_eq!(to_column(left.start), l_start);
+        assert_eq!(format!("{:?}", to_binary(left.end)), format!("{:?}", l_end));
+        assert_eq!(to_column(right.start), r_start);
+        assert_eq!(
+            format!("{:?}", to_binary(right.end)),
+            format!("{:?}", r_end)
+        );
+
+        let condition = "a.l_end > b.r_start AND b.r_end > a.l_start";
+        let ColIntervals {
+            left_interval: left,
+            right_interval: right,
+        } = extract_filter(condition).await?;
+
+        assert_eq!(to_column(left.start), l_start);
+        assert_eq!(format!("{:?}", to_binary(left.end)), format!("{:?}", l_end));
+        assert_eq!(to_column(right.start), r_start);
+        assert_eq!(
+            format!("{:?}", to_binary(right.end)),
+            format!("{:?}", r_end)
+        );
+
+        let condition = "a.l_end > b.r_start AND a.l_start < b.r_end";
+        let ColIntervals {
+            left_interval: left,
+            right_interval: right,
+        } = extract_filter(condition).await?;
+
+        assert_eq!(to_column(left.start), l_start);
+        assert_eq!(format!("{:?}", to_binary(left.end)), format!("{:?}", l_end));
+        assert_eq!(to_column(right.start), r_start);
+        assert_eq!(
+            format!("{:?}", to_binary(right.end)),
+            format!("{:?}", r_end)
+        );
+
+        let condition = "b.r_start < a.l_end AND b.r_end > a.l_start";
+        let ColIntervals {
+            left_interval: left,
+            right_interval: right,
+        } = extract_filter(condition).await?;
+
+        assert_eq!(to_column(left.start), l_start);
+        assert_eq!(format!("{:?}", to_binary(left.end)), format!("{:?}", l_end));
+        assert_eq!(to_column(right.start), r_start);
+        assert_eq!(
+            format!("{:?}", to_binary(right.end)),
+            format!("{:?}", r_end)
+        );
+
+        let condition = "b.r_start < a.l_end AND a.l_start < b.r_end";
+        let ColIntervals {
+            left_interval: left,
+            right_interval: right,
+        } = extract_filter(condition).await?;
+
+        assert_eq!(to_column(left.start), l_start);
+        assert_eq!(format!("{:?}", to_binary(left.end)), format!("{:?}", l_end));
+        assert_eq!(to_column(right.start), r_start);
+        assert_eq!(
+            format!("{:?}", to_binary(right.end)),
+            format!("{:?}", r_end)
+        );
+
+        let condition = "b.r_start < a.l_end AND a.l_start <= b.r_end";
+        let ColIntervals {
+            left_interval: left,
+            right_interval: right,
+        } = extract_filter(condition).await?;
+
+        assert_eq!(to_column(left.start), l_start);
+        assert_eq!(format!("{:?}", to_binary(left.end)), format!("{:?}", l_end));
+        assert_eq!(to_column(right.start), r_start);
+        assert_eq!(to_column(right.end), Column::new("r_end", 2));
+
+        let condition = "b.r_start <= a.l_end AND a.l_start < b.r_end";
+        let ColIntervals {
+            left_interval: left,
+            right_interval: right,
+        } = extract_filter(condition).await?;
+
+        assert_eq!(to_column(left.start), l_start);
+        assert_eq!(to_column(left.end), Column::new("l_end", 2));
+        assert_eq!(to_column(right.start), r_start);
+        assert_eq!(
+            format!("{:?}", to_binary(right.end)),
+            format!("{:?}", r_end)
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[should_panic]
+    async fn test_all_comp_combinations_for_complex_query() {
+        let condition = "(b.r_end - a.l_start) >= a.l_start AND a.l_end >= b.r_start";
+        extract_filter(condition).await.unwrap();
+    }
+
+    fn find_join_filter(plan: &Arc<dyn ExecutionPlan>) -> Result<&JoinFilter> {
+        let mut filter: Option<&JoinFilter> = None;
+        plan.apply(|plan| {
+            Ok(
+                if let Some(hash) = plan.as_any().downcast_ref::<HashJoinExec>() {
+                    filter = hash.filter();
+                    TreeNodeRecursion::Stop
+                } else if let Some(nested) = plan.as_any().downcast_ref::<NestedLoopJoinExec>() {
+                    filter = nested.filter();
+                    TreeNodeRecursion::Stop
+                } else {
+                    TreeNodeRecursion::Continue
+                },
+            )
+        })
+        .map(|_| filter.expect("filter not found"))
+    }
+
+    fn to_column(expr: Arc<dyn PhysicalExpr>) -> Column {
+        expr.as_any().downcast_ref::<Column>().unwrap().clone()
+    }
+    fn to_binary(expr: Arc<dyn PhysicalExpr>) -> BinaryExpr {
+        expr.as_any().downcast_ref::<BinaryExpr>().unwrap().clone()
+    }
+}

--- a/sequila/sequila-core/src/physical_planner/intervals.rs
+++ b/sequila/sequila-core/src/physical_planner/intervals.rs
@@ -8,15 +8,15 @@ use std::sync::Arc;
 
 #[derive(Debug, Clone)]
 pub struct ColInterval {
-    pub start: Arc<dyn PhysicalExpr>,
-    pub end: Arc<dyn PhysicalExpr>,
+    start: Arc<dyn PhysicalExpr>,
+    end: Arc<dyn PhysicalExpr>,
 }
 
 impl ColInterval {
-    fn start(&self) -> Arc<dyn PhysicalExpr> {
+    pub fn start(&self) -> Arc<dyn PhysicalExpr> {
         self.start.clone()
     }
-    fn end(&self) -> Arc<dyn PhysicalExpr> {
+    pub fn end(&self) -> Arc<dyn PhysicalExpr> {
         self.end.clone()
     }
 }
@@ -252,7 +252,7 @@ mod tests {
 
         let filter: &JoinFilter = find_join_filter(&plan)?;
 
-        try_parse(filter).map_err(|e| DataFusionError::Internal(e))
+        try_parse(filter).map_err(DataFusionError::Internal)
     }
 
     #[tokio::test]

--- a/sequila/sequila-core/src/physical_planner/joins/interval_join.rs
+++ b/sequila/sequila-core/src/physical_planner/joins/interval_join.rs
@@ -1,3 +1,4 @@
+use crate::physical_planner::intervals::{ColInterval, ColIntervals};
 use crate::physical_planner::joins::utils::symmetric_join_output_partitioning;
 use crate::physical_planner::joins::utils::{
     estimate_join_statistics, BuildProbeJoinMetrics, OnceAsync, OnceFut,
@@ -77,7 +78,7 @@ pub struct IntervalJoinExec {
     /// Filters which are applied while finding matching rows
     pub filter: Option<JoinFilter>,
     /// Columns that represent start/end of an interval
-    pub intervals: (ColInterval, ColInterval),
+    pub intervals: ColIntervals,
     /// How the join is performed (`OUTER`, `INNER`, etc)
     pub join_type: JoinType,
     /// The output schema for the join
@@ -112,7 +113,7 @@ impl IntervalJoinExec {
         right: Arc<dyn ExecutionPlan>,
         on: JoinOn,
         filter: Option<JoinFilter>,
-        intervals: (ColInterval, ColInterval),
+        intervals: ColIntervals,
         join_type: &JoinType,
         projection: Option<Vec<usize>>,
         partition_mode: PartitionMode,
@@ -443,7 +444,10 @@ impl ExecutionPlan for IntervalJoinExec {
             );
         }
 
-        let (left_interval, right_interval) = self.intervals.clone();
+        let ColIntervals {
+            left_interval,
+            right_interval,
+        } = self.intervals.clone();
 
         let join_metrics = BuildProbeJoinMetrics::new(partition, &self.metrics);
         let left_fut = match self.mode {
@@ -553,7 +557,7 @@ async fn collect_left_input(
     reservation: MemoryReservation,
     left_interval: ColInterval,
     algorithm: Algorithm,
-) -> datafusion::common::Result<JoinLeftData> {
+) -> Result<JoinLeftData> {
     let schema = left.schema();
 
     let (left_input, left_input_partition) = if let Some(partition) = partition {
@@ -1084,90 +1088,6 @@ impl Stream for IntervalJoinStream {
     }
 }
 
-trait FromPhysicalExpr {
-    fn to_binary(&self) -> Option<&BinaryExpr>;
-    fn to_column(&self) -> Option<&Column>;
-}
-
-impl FromPhysicalExpr for dyn PhysicalExpr {
-    fn to_binary(&self) -> Option<&BinaryExpr> {
-        self.as_any().downcast_ref::<BinaryExpr>()
-    }
-    fn to_column(&self) -> Option<&Column> {
-        self.as_any().downcast_ref::<Column>()
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct ColInterval {
-    start: Arc<dyn PhysicalExpr>,
-    end: Arc<dyn PhysicalExpr>,
-}
-
-impl ColInterval {
-    fn new(start: Arc<dyn PhysicalExpr>, end: Arc<dyn PhysicalExpr>) -> Self {
-        // assert_eq!(start.side, end.side, "both columns must be from the same side");
-        ColInterval { start, end }
-    }
-}
-
-fn get_with_source_index(
-    node: &Arc<dyn PhysicalExpr>,
-    indices: &[ColumnIndex],
-) -> Arc<dyn PhysicalExpr> {
-    node.clone()
-        .transform_up(|node| {
-            if let Some(column) = node.to_column() {
-                let new_column = Column::new(column.name(), indices[column.index()].index);
-                let result = Arc::new(new_column) as Arc<dyn PhysicalExpr>;
-                Ok(Transformed::yes(result))
-            } else {
-                Ok(Transformed::no(node))
-            }
-        })
-        .data()
-        .unwrap()
-}
-
-//TODO Add support for datatype, currently expected to be Int64
-pub fn parse_intervals(filter: &JoinFilter) -> Option<(ColInterval, ColInterval)> {
-    let expr = filter.expression().to_binary()?;
-    if matches!(expr.op(), Operator::And) {
-        let left = expr.left().to_binary()?;
-        let right = expr.right().to_binary()?;
-
-        let indices = filter.column_indices();
-
-        match (left.op(), right.op()) {
-            // assume that LEFT_END >= RIGHT_START in LEFT and LEFT_START <= RIGHT_END in RIGHT
-            (Operator::GtEq, Operator::LtEq) => Some((
-                ColInterval::new(
-                    get_with_source_index(right.left(), indices),
-                    get_with_source_index(left.left(), indices),
-                ),
-                ColInterval::new(
-                    get_with_source_index(left.right(), indices),
-                    get_with_source_index(right.right(), indices),
-                ),
-            )),
-            // assume that LEFT_START <= RIGHT_END in LEFT and LEFT_END >= RIGHT_START in RIGHT
-            (Operator::LtEq, Operator::GtEq) => Some((
-                ColInterval::new(
-                    get_with_source_index(left.left(), indices),
-                    get_with_source_index(right.left(), indices),
-                ),
-                ColInterval::new(
-                    get_with_source_index(right.right(), indices),
-                    get_with_source_index(left.right(), indices),
-                ),
-            )),
-            _ => None,
-        }
-    } else {
-        None
-    }
-}
-
 fn evaluate_as_i32(
     expr: Arc<dyn PhysicalExpr>,
     batch: &RecordBatch,
@@ -1399,84 +1319,6 @@ mod tests {
             assert_batches_sorted_eq!(expected, &res.clone().collect().await?);
         }
         Ok(())
-    }
-
-    #[test]
-    fn parse_filter_to_start_end() {
-        let lstart = "lstart";
-        let lend = "lend";
-        let rstart = "rstart";
-        let rend = "rend";
-
-        let gteq = BinaryExpr::new(
-            Arc::new(Column::new(lend, 1)),
-            Operator::GtEq,
-            Arc::new(Column::new(rstart, 2)),
-        );
-        let lteq = BinaryExpr::new(
-            Arc::new(Column::new(lstart, 0)),
-            Operator::LtEq,
-            Arc::new(CastExpr::new(
-                Arc::new(Column::new(rend, 3)),
-                DataType::Int64,
-                None,
-            )),
-        );
-        let expression = BinaryExpr::new(Arc::new(gteq), Operator::And, Arc::new(lteq));
-
-        let column_indices = JoinFilter::build_column_indices(vec![1, 2], vec![1, 2]);
-
-        let schema = Schema::new(vec![
-            Field::new(lstart, DataType::Int64, false),
-            Field::new(lend, DataType::Int64, false),
-            Field::new(rstart, DataType::Int64, false),
-            Field::new(rend, DataType::Int64, false),
-        ]);
-
-        // who builds it?
-        let filter = JoinFilter::new(Arc::new(expression), column_indices, schema);
-
-        let (left, right) = parse_intervals(&filter).expect("must present");
-        let expected_left = r#"ColInterval {
-    start: Column {
-        name: "lstart",
-        index: 1,
-    },
-    end: Column {
-        name: "lend",
-        index: 2,
-    },
-}"#;
-
-        assert_eq!(format!("{:#?}", left), expected_left);
-
-        let expected_right = r#"ColInterval {
-    start: Column {
-        name: "rstart",
-        index: 1,
-    },
-    end: CastExpr {
-        expr: Column {
-            name: "rend",
-            index: 2,
-        },
-        cast_type: Int64,
-        cast_options: CastOptions {
-            safe: false,
-            format_options: FormatOptions {
-                safe: true,
-                null: "",
-                date_format: None,
-                datetime_format: None,
-                timestamp_format: None,
-                timestamp_tz_format: None,
-                time_format: None,
-                duration_format: Pretty,
-            },
-        },
-    },
-}"#;
-        assert_eq!(format!("{:#?}", right), expected_right);
     }
 
     #[tokio::test]

--- a/sequila/sequila-core/src/physical_planner/joins/utils.rs
+++ b/sequila/sequila-core/src/physical_planner/joins/utils.rs
@@ -183,12 +183,12 @@ fn estimate_join_cardinality(
 
             let ij_cardinality = estimate_inner_join_cardinality(
                 Statistics {
-                    num_rows: left_stats.num_rows.clone(),
+                    num_rows: left_stats.num_rows,
                     total_byte_size: Precision::Absent,
                     column_statistics: left_col_stats,
                 },
                 Statistics {
-                    num_rows: right_stats.num_rows.clone(),
+                    num_rows: right_stats.num_rows,
                     total_byte_size: Precision::Absent,
                     column_statistics: right_col_stats,
                 },
@@ -306,7 +306,7 @@ fn estimate_inner_join_cardinality(
 /// estimates the maximum distinct count from those.
 fn max_distinct_count(num_rows: &Precision<usize>, stats: &ColumnStatistics) -> Precision<usize> {
     match &stats.distinct_count {
-        dc @ (Precision::Exact(_) | Precision::Inexact(_)) => dc.clone(),
+        dc @ (Precision::Exact(_) | Precision::Inexact(_)) => *dc,
         _ => {
             // The number can never be greater than the number of rows we have
             // minus the nulls (since they don't count as distinct values).
@@ -390,6 +390,7 @@ impl<T: 'static> OnceFut<T> {
     }
 
     /// Get the result of the computation if it is ready, without consuming it
+    #[allow(dead_code)]
     pub(crate) fn get(&mut self, cx: &mut Context<'_>) -> Poll<Result<&T>> {
         if let OnceFutState::Pending(fut) = &mut self.state {
             let r = ready!(fut.poll_unpin(cx));

--- a/sequila/sequila-core/src/physical_planner/mod.rs
+++ b/sequila/sequila-core/src/physical_planner/mod.rs
@@ -1,3 +1,4 @@
+mod intervals;
 pub mod joins;
 mod sequila_physical_planner;
 mod sequila_query_planner;

--- a/sequila/sequila-core/tests/integration_test.rs
+++ b/sequila/sequila-core/tests/integration_test.rs
@@ -325,7 +325,7 @@ async fn test_all_gt_lt_conditions(ctx: SessionContext) -> Result<()> {
     ctx.sql(a).await?;
     ctx.sql(b).await?;
 
-    let expected = vec![
+    let expected = [
         "+--------+-------+-----+--------+-------+-----+",
         "| contig | start | end | contig | start | end |",
         "+--------+-------+-----+--------+-------+-----+",


### PR DESCRIPTION
This PR:
- adds support for `</>` buy rewriting `x < y` as `x <= (y - 1)`
- fixes filter parsing bugs, old implementation considered only 2 cases: `LEFT_END >= RIGHT_START in LEFT and LEFT_START <= RIGHT_END` and `LEFT_START <= RIGHT_END in LEFT and LEFT_END >= RIGHT_START`, while there are 8.